### PR TITLE
Added the ability to mine stone and wood Tiles

### DIFF
--- a/player.py
+++ b/player.py
@@ -24,15 +24,30 @@ class Player:
         self.rectX = -25
         self.rectY = -25
 
+        # player's mining hitbox - change pygame.rect to change size of hitbox
+        self.mining_hitbox = pygame.Rect(0, 0, 150, 150)
+        self.mining_hitboxX = -75
+        self.mining_hitboxY = -75
+
+        # To track mouse clicks of left mouse button
+        self.previous_mouse_state = pygame.mouse.get_pressed()[0]
+
     def update(self):
         mouse_pos = pygame.mouse.get_pos()
         self.dir = (self.x - mouse_pos[0], self.y - mouse_pos[1])
         self.movement(500)
         self.draw()
+        # update the currently mineable tiles
+        self.get_hits_mining(self.game.map.tiles)
+        # save the previous mouse click so that you can't hold left mouse click
+        # to mine stone/wood but have to click each time
+        self.previous_mouse_state = pygame.mouse.get_pressed()[0]
 
     def draw(self):
         # make Hitbox visible
         pygame.draw.rect(self.surface, "black", self.rect)
+        # draw mining hitbox (for debugging)
+        pygame.draw.rect(self.surface, "red", self.mining_hitbox, 2)
         # (1) The player is a blue circle
         # pygame.draw.circle(self.surface, "blue", (self.x, self.y), self.r)
         # (2) The player is a robot
@@ -48,11 +63,13 @@ class Player:
         if keys[pygame.K_RIGHT]:
             self.x += speed * self.game.delta_time
         self.checkCollisionsx(self.game.map.tiles, keys)
+        self.get_hits_mining(self.game.map.tiles)
         if keys[pygame.K_UP]:
             self.y -= speed * self.game.delta_time
         if keys[pygame.K_DOWN]:
             self.y += speed * self.game.delta_time
         self.checkCollisionsy(self.game.map.tiles, keys)
+        self.get_hits_mining(self.game.map.tiles)
 
     def get_hits(self, tiles):
         hits = []
@@ -89,3 +106,44 @@ class Player:
                 self.y = tile.rect.top - self.rect.height // 2
                 self.y += self.game.offset_y
         self.rect.y = self.y + self.rectY  # Update the Hitbox Position
+
+    # check if the mining_hitbox collides with wood/stone tiles.
+    # If a collision happens and the player is clicking
+    # on the colliding tile (stone or wood) it will be mined and the resource
+    # is added to the players inventory
+    def get_hits_mining(self, tiles):
+        self.mining_hitbox.center = (self.x, self.y)
+        mouse_pos = pygame.mouse.get_pos()
+        if self.new_left_mouse_click():
+            for tile in tiles:
+                tile_rect = pygame.Rect(tile.rect.x + self.game.offset_x,
+                                        tile.rect.y + self.game.offset_y,
+                                        tile.rect.width, tile.rect.height)
+                if self.mining_hitbox.colliderect(tile_rect):
+                    # checks if the player aims at a tile and also presses
+                    # the left mouse button
+                    if self.aiming_at_tile(tile_rect, mouse_pos) and \
+                       pygame.mouse.get_pressed()[0]:
+                        if tile.tileName == "stone.png":
+                            # update the stone tile at x,y with background.png
+                            self.game.map.update_tile(tile.rect.x, tile.rect.y,
+                                                      'background.png')
+                            self.stone = self.stone + 1
+                        if tile.tileName == "wood.png":
+                            self.game.map.update_tile(tile.rect.x, tile.rect.y,
+                                                      'background.png')
+                            self.wood = self.wood + 1
+        self.mining_hitbox.center = (self.x, self.y)
+        return
+
+    # Is the mouse currently aiming at the tile tile_rect?
+    def aiming_at_tile(self, tile_rect, mouse_pos):
+        # Check if the mouse position is within the bounds of the tile
+        return tile_rect.collidepoint(mouse_pos)
+
+    # if the current LMB click is a "new" click (not holding LMB)
+    # then return true
+    def new_left_mouse_click(self):
+        current_mouse_state = pygame.mouse.get_pressed()[0]
+        is_new_click = current_mouse_state and not self.previous_mouse_state
+        return is_new_click

--- a/tiles.py
+++ b/tiles.py
@@ -26,6 +26,39 @@ class TileMap():
         self.map_surface = pygame.Surface((self.map_w, self.map_h))
         self.map_surface.set_colorkey((0, 0, 0))
         self.load_map()
+        self.tile_grid = self.create_tile_grid()
+
+    # creates a tile_grid of all the tiles so that updating a tile
+    # at a given position of the tilemap is easier to do
+    def create_tile_grid(self):
+        grid = []
+        for row in range(self.map_h // self.tile_size):
+            grid.append([None] * (self.map_w // self.tile_size))
+        for tile in self.tiles:
+            grid[tile.rect.y // self.tile_size][tile.rect.x //
+                                                self.tile_size] = tile
+        return grid
+
+    # update_tiles overrides a tile at x,y with a new tile new_tile
+    def update_tile(self, x, y, new_tile):
+        # adapt the tile coordinates to conform to the grid coordinates
+        grid_x = x // self.tile_size
+        grid_y = y // self.tile_size
+        # check if grid coordinates are within grid coordinates to avoid bugs
+        if (0 <= grid_x < len(self.tile_grid[0])) and \
+                (0 <= grid_y < len(self.tile_grid)):
+            # instantiate new tile
+            new_tile = Tile(
+                new_tile, grid_x * self.tile_size,
+                grid_y * self.tile_size, self.spritesheet
+                )
+            # replace previous tile in grid with new tile
+            self.tile_grid[grid_y][grid_x] = new_tile
+            # refresh tile list of tiles in grid
+            self.tiles = [tile for row in self.tile_grid
+                          for tile in row if tile is not None]
+            # redraw the map
+            self.load_map()
 
     def draw_map(self, surface, offset_x=0, offset_y=0):
         for tile in self.tiles:


### PR DESCRIPTION
resolves #30 

- added the ability for the player to click on a stone/wood tile and "mine" that tile
- the resources mined will be stored to the wood/stone attribute 
- added a function which tracks whether left mouse button is clicked or being held, only clicks will mine a tile
- added a grid and an update function to tiles.py so that dynamic changes to the tilemap are easier

potential ideas for better mining:
- add a "cooldown" between clicks so that it takes a bit longer to mine resources
-> add an animation of a tool swinging between each click
- mining one stone/wood should take at least 2-3 clicks
-> partially mined materials could have cracks in them (like minecraft)