### PR TITLE
Adjusting options menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ class Game:
         self.offset_y = (self.window_height - self.map.map_h) // 2
 
         self.player = player.Player(
-            self, 500, 450, 10, 0, 0, 1, 1, 0, weapon.Knife())
+            self, 500, 450, 10, 0, 0, 1, 1, 0, weapon.Knife(),"wasd")
         self.main_menu()
 
     def main_menu(self):
@@ -123,15 +123,22 @@ class Game:
 
             OPT_CHANGE_ROBOT = Button(image=None,
                                      pos=(self.window_width * 0.5,
-                                     self.window_height * 0.35),
+                                     self.window_height * 0.45),
                                      text_input="CHANGE ROBOT",
+                                     font=get_font(75),
+                                     base_color="Black",
+                                     hovering_color="Green")
+            OPT_KEY_ASSIGNMENT = Button(image=None,
+                                     pos=(self.window_width * 0.5,
+                                     self.window_height * 0.35),
+                                     text_input="CHANGE KEY ASSIGNMENT",
                                      font=get_font(75),
                                      base_color="Black",
                                      hovering_color="Green")
             
             OPT_BACK = Button(image=None,
                               pos=(self.window_width * 0.5,
-                                   self.window_height * 0.45),
+                                   self.window_height * 0.55),
                               text_input="BACK",
                               font=get_font(75),
                               base_color="Black",
@@ -139,6 +146,8 @@ class Game:
 
             OPT_CHANGE_ROBOT.changeColor(OPT_MOUSE_POS)
             OPT_CHANGE_ROBOT.update(self.canvas)
+            OPT_KEY_ASSIGNMENT.changeColor(OPT_MOUSE_POS)
+            OPT_KEY_ASSIGNMENT.update(self.canvas)
             OPT_BACK.changeColor(OPT_MOUSE_POS)
             OPT_BACK.update(self.canvas)
 
@@ -151,6 +160,8 @@ class Game:
                         self.main_menu()
                     if OPT_CHANGE_ROBOT.checkForInput(OPT_MOUSE_POS):
                         self.change_robot_screen()
+                    if OPT_KEY_ASSIGNMENT.checkForInput(OPT_MOUSE_POS):
+                        self.key_assignment()
 
             self.window.blit(self.canvas, (0, 0))
             pygame.display.update()
@@ -158,7 +169,7 @@ class Game:
     def change_robot_screen(self):
         while True:
             self.canvas.fill("green")
-            OPT_MOUSE_POS = pygame.mouse.get_pos()
+            MOUSE_POS = pygame.mouse.get_pos()
 
             OPT_BACK = Button(image=None,
                               pos=(self.window_width * 0.5,
@@ -167,7 +178,7 @@ class Game:
                               font=get_font(75),
                               base_color="Black",
                               hovering_color="White")
-            OPT_BACK.changeColor(OPT_MOUSE_POS)
+            OPT_BACK.changeColor(MOUSE_POS)
             OPT_BACK.update(self.canvas)
 
             for event in pygame.event.get():
@@ -175,7 +186,7 @@ class Game:
                     pygame.quit()
                     sys.exit()
                 if event.type == pygame.MOUSEBUTTONDOWN:
-                    if OPT_BACK.checkForInput(OPT_MOUSE_POS):
+                    if OPT_BACK.checkForInput(MOUSE_POS):
                         self.main_menu()
 
             self.window.blit(self.canvas, (0, 0))

--- a/main.py
+++ b/main.py
@@ -51,7 +51,7 @@ class Game:
         self.offset_y = (self.window_height - self.map.map_h) // 2
 
         self.player = player.Player(
-            self, 500, 450, 10, 0, 0, 1, 1, 0, weapon.Knife(),"wasd")
+            self, x = 500, y = 450, energy = 10, wood = 0, stone = 0, speed = 1, healing = 1, points = 0, weapon = weapon.Knife(),keymode = "wasd")
         self.main_menu()
 
     def main_menu(self):
@@ -185,6 +185,60 @@ class Game:
                 if event.type == pygame.QUIT:
                     pygame.quit()
                     sys.exit()
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if OPT_BACK.checkForInput(MOUSE_POS):
+                        self.main_menu()
+
+            self.window.blit(self.canvas, (0, 0))
+            pygame.display.update()
+
+    def key_assignment(self):
+        while True:
+            self.canvas.fill("grey")
+            MOUSE_POS = pygame.mouse.get_pos()
+
+            KEY_A_WASD = Button(image=None,
+                              pos=(self.window_width * 0.3,
+                                   self.window_height * 0.45),
+                              text_input="WASD",
+                              font=get_font(75),
+                              base_color="Black",
+                              hovering_color="Green")
+            
+            KEY_A_ARROWS = Button(image=None,
+                              pos=(self.window_width * 0.7,
+                                   self.window_height * 0.45),
+                              text_input="ARROWS",
+                              font=get_font(75),
+                              base_color="Black",
+                              hovering_color="Green")
+
+            OPT_BACK = Button(image=None,
+                              pos=(self.window_width * 0.5,
+                                   self.window_height * 0.55),
+                              text_input="BACK",
+                              font=get_font(75),
+                              base_color="Black",
+                              hovering_color="White")
+            KEY_A_WASD.changeColor(MOUSE_POS)
+            KEY_A_WASD.update(self.canvas)
+            KEY_A_ARROWS.changeColor(MOUSE_POS)
+            KEY_A_ARROWS.update(self.canvas)
+            OPT_BACK.changeColor(MOUSE_POS)
+            OPT_BACK.update(self.canvas)
+
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if KEY_A_WASD.checkForInput(MOUSE_POS):
+                        self.player.keymode = "wasd"
+                        self.main_menu()
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if KEY_A_ARROWS.checkForInput(MOUSE_POS):
+                        self.player.keymode = "arrows"
+                        self.main_menu()
                 if event.type == pygame.MOUSEBUTTONDOWN:
                     if OPT_BACK.checkForInput(MOUSE_POS):
                         self.main_menu()

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 import os
 import player
 import weapon
+from menu_screen import Menu
 from spritesheet import Spritesheet
 from tiles import TileMap
 from button import Button
@@ -54,25 +55,19 @@ class Game:
             self, x = 500, y = 450, energy = 10, wood = 0, stone = 0, speed = 1, healing = 1, points = 0, weapon = weapon.Knife(),keymode = "wasd")
         self.main_menu()
 
+    def quit(self):
+        pygame.quit()
+        sys.exit()
+    
     def main_menu(self):
-        while True:
-            # Fills the entire screen with dark grey
-            self.canvas.fill((25, 25, 25))
-
-            MENU_MOUSE_POS = pygame.mouse.get_pos()
-
-            MENU_TEXT = get_font(100).render("MAIN MENU", True, "#b68f40")
-            MENU_RECT = MENU_TEXT.get_rect(center=(self.window_width * 0.5,
-                                                   self.window_height * 0.15))
-
-            PLAY_BTN = Button(image=pygame.image.load("assets/Play Rect.png"),
+        PLAY_BTN = Button(image=pygame.image.load("assets/Play Rect.png"),
                               pos=(self.window_width * 0.5,
                                    self.window_height * 0.35),
                               text_input="PLAY",
                               font=get_font(75),
                               base_color="#d7fcd4",
                               hovering_color="White")
-            OPT_BTN = Button(image=pygame.image.load(
+        OPT_BTN = Button(image=pygame.image.load(
                             "assets/Options Rect.png"),
                              pos=(self.window_width * 0.5,
                                   self.window_height * 0.5),
@@ -80,7 +75,7 @@ class Game:
                              font=get_font(75),
                              base_color="#d7fcd4",
                              hovering_color="White")
-            QUIT_BTN = Button(image=pygame.image.load(
+        QUIT_BTN = Button(image=pygame.image.load(
                             "assets/Quit Rect.png"),
                               pos=(self.window_width * 0.5,
                                    self.window_height * 0.65),
@@ -89,46 +84,24 @@ class Game:
                               base_color="#d7fcd4",
                               hovering_color="White")
 
-            self.canvas.blit(MENU_TEXT, MENU_RECT)
+        buttons = [PLAY_BTN, OPT_BTN, QUIT_BTN]
 
-            for button in [PLAY_BTN, OPT_BTN, QUIT_BTN]:
-                button.changeColor(MENU_MOUSE_POS)
-                button.update(self.canvas)
-
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if PLAY_BTN.checkForInput(MENU_MOUSE_POS):
-                        self.play()
-                    if OPT_BTN.checkForInput(MENU_MOUSE_POS):
-                        self.options()
-                    if QUIT_BTN.checkForInput(MENU_MOUSE_POS):
-                        pygame.quit()
-                        sys.exit()
-            self.window.blit(self.canvas, (0, 0))
-            pygame.display.update()
+        functions = [
+            self.play, #play button
+            self.options, #options buttons
+            self.quit #quit button
+        ]
+        Menu(self.window, "MAIN MENU", (self.window_width * 0.5, self.window_height * 0.15), buttons, functions, "#b68f40", "#252525")
 
     def options(self):
-        while True:
-            OPT_MOUSE_POS = pygame.mouse.get_pos()
-
-            self.canvas.fill("white")
-
-            OPT_TEXT = get_font(45).render("OPTIONS screen.", True, "Black")
-            OPT_RECT = OPT_TEXT.get_rect(center=(self.window_width * 0.5,
-                                                 self.window_height * 0.25))
-            self.canvas.blit(OPT_TEXT, OPT_RECT)
-
-            OPT_CHANGE_ROBOT = Button(image=None,
+        OPT_CHANGE_ROBOT = Button(image=None,
                                      pos=(self.window_width * 0.5,
                                      self.window_height * 0.45),
                                      text_input="CHANGE ROBOT",
                                      font=get_font(75),
                                      base_color="Black",
                                      hovering_color="Green")
-            OPT_KEY_ASSIGNMENT = Button(image=None,
+        OPT_KEY_ASSIGNMENT = Button(image=None,
                                      pos=(self.window_width * 0.5,
                                      self.window_height * 0.35),
                                      text_input="CHANGE KEY ASSIGNMENT",
@@ -136,68 +109,38 @@ class Game:
                                      base_color="Black",
                                      hovering_color="Green")
             
-            OPT_BACK = Button(image=None,
+        OPT_BACK = Button(image=None,
                               pos=(self.window_width * 0.5,
                                    self.window_height * 0.55),
                               text_input="BACK",
                               font=get_font(75),
                               base_color="Black",
                               hovering_color="Green")
+        
+        buttons = [OPT_CHANGE_ROBOT, OPT_KEY_ASSIGNMENT, OPT_BACK]
 
-            OPT_CHANGE_ROBOT.changeColor(OPT_MOUSE_POS)
-            OPT_CHANGE_ROBOT.update(self.canvas)
-            OPT_KEY_ASSIGNMENT.changeColor(OPT_MOUSE_POS)
-            OPT_KEY_ASSIGNMENT.update(self.canvas)
-            OPT_BACK.changeColor(OPT_MOUSE_POS)
-            OPT_BACK.update(self.canvas)
-
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if OPT_BACK.checkForInput(OPT_MOUSE_POS):
-                        self.main_menu()
-                    if OPT_CHANGE_ROBOT.checkForInput(OPT_MOUSE_POS):
-                        self.change_robot_screen()
-                    if OPT_KEY_ASSIGNMENT.checkForInput(OPT_MOUSE_POS):
-                        self.key_assignment()
-
-            self.window.blit(self.canvas, (0, 0))
-            pygame.display.update()
+        functions = [self.change_robot_screen,
+                      self.key_assignment,
+                      self.key_assignment]
+        
+        Menu(self.window, "OPTIONS screen", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "Grey")
     
     def change_robot_screen(self):
-        while True:
-            self.canvas.fill("green")
-            MOUSE_POS = pygame.mouse.get_pos()
-
-            OPT_BACK = Button(image=None,
+        C_R_BACK = Button(image=None,
                               pos=(self.window_width * 0.5,
                                    self.window_height * 0.45),
                               text_input="BACK",
                               font=get_font(75),
                               base_color="Black",
                               hovering_color="White")
-            OPT_BACK.changeColor(MOUSE_POS)
-            OPT_BACK.update(self.canvas)
+        
+        buttons = [C_R_BACK]
 
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if OPT_BACK.checkForInput(MOUSE_POS):
-                        self.main_menu()
-
-            self.window.blit(self.canvas, (0, 0))
-            pygame.display.update()
+        functions = [self.main_menu]
+        Menu(self.window, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
 
     def key_assignment(self):
-        while True:
-            self.canvas.fill("grey")
-            MOUSE_POS = pygame.mouse.get_pos()
-
-            KEY_A_WASD = Button(image=None,
+        KEY_A_WASD = Button(image=None,
                               pos=(self.window_width * 0.3,
                                    self.window_height * 0.45),
                               text_input="WASD",
@@ -205,7 +148,7 @@ class Game:
                               base_color="Black",
                               hovering_color="Green")
             
-            KEY_A_ARROWS = Button(image=None,
+        KEY_A_ARROWS = Button(image=None,
                               pos=(self.window_width * 0.7,
                                    self.window_height * 0.45),
                               text_input="ARROWS",
@@ -213,38 +156,19 @@ class Game:
                               base_color="Black",
                               hovering_color="Green")
 
-            OPT_BACK = Button(image=None,
+        KEY_A_BACK = Button(image=None,
                               pos=(self.window_width * 0.5,
                                    self.window_height * 0.55),
                               text_input="BACK",
                               font=get_font(75),
                               base_color="Black",
                               hovering_color="White")
-            KEY_A_WASD.changeColor(MOUSE_POS)
-            KEY_A_WASD.update(self.canvas)
-            KEY_A_ARROWS.changeColor(MOUSE_POS)
-            KEY_A_ARROWS.update(self.canvas)
-            OPT_BACK.changeColor(MOUSE_POS)
-            OPT_BACK.update(self.canvas)
+        
+        buttons = [KEY_A_WASD, KEY_A_ARROWS, KEY_A_BACK]
 
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    pygame.quit()
-                    sys.exit()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if KEY_A_WASD.checkForInput(MOUSE_POS):
-                        self.player.keymode = "wasd"
-                        self.main_menu()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if KEY_A_ARROWS.checkForInput(MOUSE_POS):
-                        self.player.keymode = "arrows"
-                        self.main_menu()
-                if event.type == pygame.MOUSEBUTTONDOWN:
-                    if OPT_BACK.checkForInput(MOUSE_POS):
-                        self.main_menu()
+        functions = [lambda: (setattr(self.player, 'keymode', 'wasd'), self.main_menu())[1], lambda: (setattr(self.player, 'keymode', 'arrows'), self.main_menu())[1], self.main_menu]
 
-            self.window.blit(self.canvas, (0, 0))
-            pygame.display.update()
+        Menu(self.window, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
 
     def get_upgrade_cost(self, ability, ressource):
         if ability == "speed":

--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ class Game:
                     if OPT_BACK.checkForInput(OPT_MOUSE_POS):
                         self.main_menu()
 
-            self.canvas.blit(self.canvas, (0, 0))
+            self.window.blit(self.canvas, (0, 0))
             pygame.display.update()
 
     def get_upgrade_cost(self, ability, ressource):

--- a/main.py
+++ b/main.py
@@ -52,12 +52,8 @@ class Game:
         self.offset_y = (self.window_height - self.map.map_h) // 2
 
         self.player = player.Player(
-            self, x = 500, y = 450, energy = 10, wood = 0, stone = 0, speed = 1, healing = 1, points = 0, weapon = weapon.Knife(),keymode = "wasd")
+            self, x = 500, y = 450, energy = 10, wood = 0, stone = 0, speed = 1, healing = 1, points = 0, weapon = weapon.Knife(), keymode = "wasd")
         self.main_menu()
-
-    def quit(self):
-        pygame.quit()
-        sys.exit()
     
     def main_menu(self):
         PLAY_BTN = Button(image=pygame.image.load("assets/Play Rect.png"),
@@ -89,9 +85,10 @@ class Game:
         functions = [
             self.play, #play button
             self.options, #options buttons
-            self.quit #quit button
+            lambda: (pygame.quit(), sys.exit())[1] #quit button
         ]
-        Menu(self.window, "MAIN MENU", (self.window_width * 0.5, self.window_height * 0.15), buttons, functions, "#b68f40", "#252525")
+        while True:
+            Menu(self.window, self.canvas, "MAIN MENU", (self.window_width * 0.5, self.window_height * 0.15), buttons, functions, "#b68f40", "#252525")
 
     def options(self):
         OPT_CHANGE_ROBOT = Button(image=None,
@@ -121,9 +118,9 @@ class Game:
 
         functions = [self.change_robot_screen,
                       self.key_assignment,
-                      self.key_assignment]
+                      self.main_menu]
         
-        Menu(self.window, "OPTIONS screen", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "Grey")
+        Menu(self.window, self.canvas, "OPTIONS screen", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "Grey")
     
     def change_robot_screen(self):
         C_R_BACK = Button(image=None,
@@ -137,7 +134,7 @@ class Game:
         buttons = [C_R_BACK]
 
         functions = [self.main_menu]
-        Menu(self.window, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
+        Menu(self.window, self.canvas, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
 
     def key_assignment(self):
         KEY_A_WASD = Button(image=None,
@@ -168,7 +165,7 @@ class Game:
 
         functions = [lambda: (setattr(self.player, 'keymode', 'wasd'), self.main_menu())[1], lambda: (setattr(self.player, 'keymode', 'arrows'), self.main_menu())[1], self.main_menu]
 
-        Menu(self.window, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
+        Menu(self.window, self.canvas, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
 
     def get_upgrade_cost(self, ability, ressource):
         if ability == "speed":

--- a/main.py
+++ b/main.py
@@ -121,6 +121,14 @@ class Game:
                                                  self.window_height * 0.25))
             self.canvas.blit(OPT_TEXT, OPT_RECT)
 
+            OPT_CHANGE_ROBOT = Button(image=None,
+                                     pos=(self.window_width * 0.5,
+                                     self.window_height * 0.35),
+                                     text_input="CHANGE ROBOT",
+                                     font=get_font(75),
+                                     base_color="Black",
+                                     hovering_color="Green")
+            
             OPT_BACK = Button(image=None,
                               pos=(self.window_width * 0.5,
                                    self.window_height * 0.45),
@@ -129,6 +137,36 @@ class Game:
                               base_color="Black",
                               hovering_color="Green")
 
+            OPT_CHANGE_ROBOT.changeColor(OPT_MOUSE_POS)
+            OPT_CHANGE_ROBOT.update(self.canvas)
+            OPT_BACK.changeColor(OPT_MOUSE_POS)
+            OPT_BACK.update(self.canvas)
+
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    if OPT_BACK.checkForInput(OPT_MOUSE_POS):
+                        self.main_menu()
+                    if OPT_CHANGE_ROBOT.checkForInput(OPT_MOUSE_POS):
+                        self.change_robot_screen()
+
+            self.window.blit(self.canvas, (0, 0))
+            pygame.display.update()
+    
+    def change_robot_screen(self):
+        while True:
+            self.canvas.fill("green")
+            OPT_MOUSE_POS = pygame.mouse.get_pos()
+
+            OPT_BACK = Button(image=None,
+                              pos=(self.window_width * 0.5,
+                                   self.window_height * 0.45),
+                              text_input="BACK",
+                              font=get_font(75),
+                              base_color="Black",
+                              hovering_color="White")
             OPT_BACK.changeColor(OPT_MOUSE_POS)
             OPT_BACK.update(self.canvas)
 

--- a/main.py
+++ b/main.py
@@ -52,99 +52,103 @@ class Game:
         self.offset_y = (self.window_height - self.map.map_h) // 2
 
         self.player = player.Player(
-            self, x = 500, y = 450, energy = 10, wood = 0, stone = 0, speed = 1, healing = 1, points = 0, weapon = weapon.Knife(), keymode = "wasd")
+            self, x=500, y=450, energy=10, wood=0, stone=0, speed=1, healing=1,
+            points=0, weapon=weapon.Knife(), keymode="wasd"
+        )
         self.main_menu()
-    
+
     def main_menu(self):
         PLAY_BTN = Button(image=pygame.image.load("assets/Play Rect.png"),
-                              pos=(self.window_width * 0.5,
-                                   self.window_height * 0.35),
-                              text_input="PLAY",
-                              font=get_font(75),
-                              base_color="#d7fcd4",
-                              hovering_color="White")
-        OPT_BTN = Button(image=pygame.image.load(
-                            "assets/Options Rect.png"),
-                             pos=(self.window_width * 0.5,
-                                  self.window_height * 0.5),
-                             text_input="OPTIONS",
-                             font=get_font(75),
-                             base_color="#d7fcd4",
-                             hovering_color="White")
-        QUIT_BTN = Button(image=pygame.image.load(
-                            "assets/Quit Rect.png"),
-                              pos=(self.window_width * 0.5,
-                                   self.window_height * 0.65),
-                              text_input="QUIT",
-                              font=get_font(75),
-                              base_color="#d7fcd4",
-                              hovering_color="White")
+                          pos=(self.window_width * 0.5,
+                          self.window_height * 0.35),
+                          text_input="PLAY",
+                          font=get_font(75),
+                          base_color="#d7fcd4",
+                          hovering_color="White")
+        OPT_BTN = Button(image=pygame.image.load("assets/Options Rect.png"),
+                         pos=(self.window_width * 0.5,
+                              self.window_height * 0.5),
+                         text_input="OPTIONS",
+                         font=get_font(75),
+                         base_color="#d7fcd4",
+                         hovering_color="White")
+        QUIT_BTN = Button(image=pygame.image.load("assets/Quit Rect.png"),
+                          pos=(self.window_width * 0.5,
+                               self.window_height * 0.65),
+                          text_input="QUIT",
+                          font=get_font(75),
+                          base_color="#d7fcd4",
+                          hovering_color="White")
 
         buttons = [PLAY_BTN, OPT_BTN, QUIT_BTN]
 
         functions = [
-            self.play, #play button
-            self.options, #options buttons
-            lambda: (pygame.quit(), sys.exit())[1] #quit button
+            self.play,  # play button
+            self.options,  # options buttons
+            lambda: (pygame.quit(), sys.exit())[1]  # quit button
         ]
         while True:
-            Menu(self.window, self.canvas, "MAIN MENU", (self.window_width * 0.5, self.window_height * 0.15), buttons, functions, "#b68f40", "#252525")
+            Menu(self.window, self.canvas, "MAIN MENU",
+                 (self.window_width * 0.5, self.window_height * 0.15),
+                 buttons, functions, "#b68f40", "#252525")
 
     def options(self):
         OPT_CHANGE_ROBOT = Button(image=None,
-                                     pos=(self.window_width * 0.5,
-                                     self.window_height * 0.45),
-                                     text_input="CHANGE ROBOT",
-                                     font=get_font(75),
-                                     base_color="Black",
-                                     hovering_color="Green")
+                                  pos=(self.window_width * 0.5,
+                                       self.window_height * 0.45),
+                                  text_input="CHANGE ROBOT",
+                                  font=get_font(75),
+                                  base_color="Black",
+                                  hovering_color="Green")
         OPT_KEY_ASSIGNMENT = Button(image=None,
-                                     pos=(self.window_width * 0.5,
-                                     self.window_height * 0.35),
-                                     text_input="CHANGE KEY ASSIGNMENT",
-                                     font=get_font(75),
-                                     base_color="Black",
-                                     hovering_color="Green")
-            
+                                    pos=(self.window_width * 0.5,
+                                         self.window_height * 0.35),
+                                    text_input="CHANGE KEY ASSIGNMENT",
+                                    font=get_font(75),
+                                    base_color="Black",
+                                    hovering_color="Green")
+
         OPT_BACK = Button(image=None,
-                              pos=(self.window_width * 0.5,
-                                   self.window_height * 0.55),
-                              text_input="BACK",
-                              font=get_font(75),
-                              base_color="Black",
-                              hovering_color="Green")
-        
+                          pos=(self.window_width * 0.5,
+                               self.window_height * 0.55),
+                          text_input="BACK",
+                          font=get_font(75),
+                          base_color="Black",
+                          hovering_color="Green")
+
         buttons = [OPT_CHANGE_ROBOT, OPT_KEY_ASSIGNMENT, OPT_BACK]
 
         functions = [self.change_robot_screen,
-                      self.key_assignment,
-                      self.main_menu]
-        
-        Menu(self.window, self.canvas, "OPTIONS screen", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "Grey")
-    
+                     self.key_assignment, self.main_menu]
+
+        Menu(self.window, self.canvas, "OPTIONS screen",
+             (self.window_width * 0.5, self.window_height * 0.25),
+             buttons, functions, "Black", "Grey")
+
     def change_robot_screen(self):
         C_R_BACK = Button(image=None,
-                              pos=(self.window_width * 0.5,
-                                   self.window_height * 0.45),
-                              text_input="BACK",
-                              font=get_font(75),
-                              base_color="Black",
-                              hovering_color="White")
-        
+                          pos=(self.window_width * 0.5,
+                               self.window_height * 0.45),
+                          text_input="BACK",
+                          font=get_font(75),
+                          base_color="Black",
+                          hovering_color="White")
+
         buttons = [C_R_BACK]
 
         functions = [self.main_menu]
-        Menu(self.window, self.canvas, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
+        Menu(self.window, self.canvas, "", (0, 0),
+             buttons, functions, "Black", "White")
 
     def key_assignment(self):
         KEY_A_WASD = Button(image=None,
-                              pos=(self.window_width * 0.3,
-                                   self.window_height * 0.45),
-                              text_input="WASD",
-                              font=get_font(75),
-                              base_color="Black",
-                              hovering_color="Green")
-            
+                            pos=(self.window_width * 0.3,
+                                 self.window_height * 0.45),
+                            text_input="WASD",
+                            font=get_font(75),
+                            base_color="Black",
+                            hovering_color="Green")
+
         KEY_A_ARROWS = Button(image=None,
                               pos=(self.window_width * 0.7,
                                    self.window_height * 0.45),
@@ -154,18 +158,25 @@ class Game:
                               hovering_color="Green")
 
         KEY_A_BACK = Button(image=None,
-                              pos=(self.window_width * 0.5,
-                                   self.window_height * 0.55),
-                              text_input="BACK",
-                              font=get_font(75),
-                              base_color="Black",
-                              hovering_color="White")
-        
+                            pos=(self.window_width * 0.5,
+                                 self.window_height * 0.55),
+                            text_input="BACK",
+                            font=get_font(75),
+                            base_color="Black",
+                            hovering_color="White")
+
         buttons = [KEY_A_WASD, KEY_A_ARROWS, KEY_A_BACK]
 
-        functions = [lambda: (setattr(self.player, 'keymode', 'wasd'), self.main_menu())[1], lambda: (setattr(self.player, 'keymode', 'arrows'), self.main_menu())[1], self.main_menu]
+        functions = [lambda:
+                     (setattr(self.player, 'keymode', 'wasd'),
+                      self.main_menu())[1],
+                     lambda:
+                     (setattr(self.player, 'keymode', 'arrows'),
+                      self.main_menu())[1],
+                     self.main_menu]
 
-        Menu(self.window, self.canvas, "", (self.window_width * 0.5, self.window_height * 0.25), buttons, functions, "Black", "White")
+        Menu(self.window, self.canvas, "", (0, 0),
+             buttons, functions, "Black", "White")
 
     def get_upgrade_cost(self, ability, ressource):
         if ability == "speed":

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -6,9 +6,7 @@ def get_font(size):  # Returns Press-Start-2P in the desired size
     return pygame.font.Font("assets/font.ttf", size)
 
 class Menu:
-    def __init__(self, window, title, title_pos, buttons, functions, title_color, bg_color):
-        info = pygame.display.Info()
-        canvas = pygame.Surface((info.current_w, info.current_h))
+    def __init__(self, window, canvas, title, title_pos, buttons, functions, title_color, bg_color):
         while True:
             canvas.fill(bg_color)
 
@@ -16,11 +14,13 @@ class Menu:
 
             TITLE_TEXT = get_font(100).render(title, True, title_color)
             TITLE_RECT = TITLE_TEXT.get_rect(center=title_pos)
-            canvas.blit(TITLE_TEXT, TITLE_RECT)
+            # canvas.blit(TITLE_TEXT, TITLE_RECT)
 
             for b in buttons:
                 b.changeColor(MOUSE_POS)
                 b.update(canvas)
+            
+            canvas.blit(TITLE_TEXT, TITLE_RECT)
 
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -1,12 +1,14 @@
 import pygame
 import sys
-from button import Button # needed?
+
 
 def get_font(size):  # Returns Press-Start-2P in the desired size
     return pygame.font.Font("assets/font.ttf", size)
 
+
 class Menu:
-    def __init__(self, window, canvas, title, title_pos, buttons, functions, title_color, bg_color):
+    def __init__(self, window, canvas, title,
+                 title_pos, buttons, functions, title_color, bg_color):
         while True:
             canvas.fill(bg_color)
 
@@ -19,7 +21,7 @@ class Menu:
             for b in buttons:
                 b.changeColor(MOUSE_POS)
                 b.update(canvas)
-            
+
             canvas.blit(TITLE_TEXT, TITLE_RECT)
 
             for event in pygame.event.get():

--- a/menu_screen.py
+++ b/menu_screen.py
@@ -1,0 +1,36 @@
+import pygame
+import sys
+from button import Button # needed?
+
+def get_font(size):  # Returns Press-Start-2P in the desired size
+    return pygame.font.Font("assets/font.ttf", size)
+
+class Menu:
+    def __init__(self, window, title, title_pos, buttons, functions, title_color, bg_color):
+        info = pygame.display.Info()
+        canvas = pygame.Surface((info.current_w, info.current_h))
+        while True:
+            canvas.fill(bg_color)
+
+            MOUSE_POS = pygame.mouse.get_pos()
+
+            TITLE_TEXT = get_font(100).render(title, True, title_color)
+            TITLE_RECT = TITLE_TEXT.get_rect(center=title_pos)
+            canvas.blit(TITLE_TEXT, TITLE_RECT)
+
+            for b in buttons:
+                b.changeColor(MOUSE_POS)
+                b.update(canvas)
+
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    sys.exit()
+                if event.type == pygame.MOUSEBUTTONDOWN:
+                    i = -1
+                    for b in buttons:
+                        i += 1
+                        if b.checkForInput(MOUSE_POS):
+                            return functions[i]()
+            window.blit(canvas, (0, 0))
+            pygame.display.update()

--- a/player.py
+++ b/player.py
@@ -87,10 +87,10 @@ class Player:
     def movement(self, speed):
         keys = pygame.key.get_pressed()
         dx, dy = 0, 0
-        l = False
-        r = False
-        u = False
-        d = False
+        l_pressed = False
+        r_pressed = False
+        u_pressed = False
+        d_pressed = False
         if self.keymode == "wasd":
             left = pygame.K_a
             right = pygame.K_d
@@ -103,16 +103,16 @@ class Player:
             down = pygame.K_DOWN
         if keys[left]:
             dx -= speed * self.game.delta_time
-            l = True
+            l_pressed = True
         if keys[right]:
             dx += speed * self.game.delta_time
-            r = True
+            r_pressed = True
         if keys[up]:
             dy -= speed * self.game.delta_time
-            u = True
+            u_pressed = True
         if keys[down]:
             dy += speed * self.game.delta_time
-            d = True
+            d_pressed = True
 
         # Aufteilen der Bewegung in kleinere Schritte
         steps = max(abs(dx), abs(dy))
@@ -125,10 +125,10 @@ class Player:
         for _ in range(int(steps)):
             if dx != 0:
                 self.x += dx
-                self.checkCollisionsx(l, r)
+                self.checkCollisionsx(l_pressed, r_pressed)
             if dy != 0:
                 self.y += dy
-                self.checkCollisionsy(u, d)
+                self.checkCollisionsy(u_pressed, d_pressed)
 
     def get_collisions(self):
         hits = []
@@ -157,25 +157,25 @@ class Player:
                     hits.append(tile_rect)
         return hits
 
-    def checkCollisionsx(self, l, r):
+    def checkCollisionsx(self, l_pressed, r_pressed):
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
         collisions = self.get_collisions()
         for tile_rect in collisions:
-            if l:
+            if l_pressed:
                 self.x = tile_rect.right + self.rect.width // 2
-            if r:
+            if r_pressed:
                 self.x = tile_rect.left - self.rect.width // 2
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
 
-    def checkCollisionsy(self, u, d):
+    def checkCollisionsy(self, u_pressed, d_pressed):
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
         self.rect.bottom += 1
         self.rect.top -= 1
         collisions = self.get_collisions()
         for tile_rect in collisions:
-            if u:
+            if u_pressed:
                 self.y = tile_rect.bottom + self.rect.height // 2
-            if d:
+            if d_pressed:
                 self.y = tile_rect.top - self.rect.height // 2
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
 

--- a/player.py
+++ b/player.py
@@ -4,7 +4,7 @@ import bullet
 
 class Player:
     def __init__(self, game, x, y, energy, wood, stone,
-                 speed, healing, points, weapon):
+                 speed, healing, points, weapon, keymode):
         self.x = x
         self.y = y
         self.energy = energy
@@ -19,6 +19,7 @@ class Player:
         self.image = pygame.image.load('assets/robot.png').convert_alpha()
         self.image = pygame.transform.scale(self.image, (40, 40))
         self.weapon = weapon
+        self.keymode = keymode
 
         self.tileTupleList = []
         for tile in self.game.map.tiles:
@@ -86,14 +87,32 @@ class Player:
     def movement(self, speed):
         keys = pygame.key.get_pressed()
         dx, dy = 0, 0
-        if keys[pygame.K_LEFT]:
+        l = False
+        r = False
+        u = False
+        d = False
+        if self.keymode == "wasd":
+            left = pygame.K_a
+            right = pygame.K_d
+            up = pygame.K_w
+            down = pygame.K_s
+        else:
+            left = pygame.K_LEFT
+            right = pygame.K_RIGHT
+            up = pygame.K_UP
+            down = pygame.K_DOWN
+        if keys[left]:
             dx -= speed * self.game.delta_time
-        if keys[pygame.K_RIGHT]:
+            l = True
+        if keys[right]:
             dx += speed * self.game.delta_time
-        if keys[pygame.K_UP]:
+            r = True
+        if keys[up]:
             dy -= speed * self.game.delta_time
-        if keys[pygame.K_DOWN]:
+            u = True
+        if keys[down]:
             dy += speed * self.game.delta_time
+            d = True
 
         # Aufteilen der Bewegung in kleinere Schritte
         steps = max(abs(dx), abs(dy))
@@ -106,10 +125,10 @@ class Player:
         for _ in range(int(steps)):
             if dx != 0:
                 self.x += dx
-                self.checkCollisionsx(keys)
+                self.checkCollisionsx(l, r)
             if dy != 0:
                 self.y += dy
-                self.checkCollisionsy(keys)
+                self.checkCollisionsy(u, d)
 
     def get_collisions(self):
         hits = []
@@ -138,25 +157,25 @@ class Player:
                     hits.append(tile_rect)
         return hits
 
-    def checkCollisionsx(self, keys):
+    def checkCollisionsx(self, l, r):
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
         collisions = self.get_collisions()
         for tile_rect in collisions:
-            if keys[pygame.K_LEFT]:
+            if l:
                 self.x = tile_rect.right + self.rect.width // 2
-            if keys[pygame.K_RIGHT]:
+            if r:
                 self.x = tile_rect.left - self.rect.width // 2
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
 
-    def checkCollisionsy(self, keys):
+    def checkCollisionsy(self, u, d):
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
         self.rect.bottom += 1
         self.rect.top -= 1
         collisions = self.get_collisions()
         for tile_rect in collisions:
-            if keys[pygame.K_UP]:
+            if u:
                 self.y = tile_rect.bottom + self.rect.height // 2
-            if keys[pygame.K_DOWN]:
+            if d:
                 self.y = tile_rect.top - self.rect.height // 2
         self.rect.center = (self.x, self.y)  # Update the Hitbox Position
 


### PR DESCRIPTION
Resolves #60 
I added the option to switch between a "wasd"-key assignment and the arrow keys.
This can be done in the "options"-menu. There is also now an option to "change robot", where our different robot designs can be added.
To remove unnecessary repetitions and to make implementing other menu screens easier, i also added a Menu()-class in a new file called menu_screen.py.